### PR TITLE
Update password manager

### DIFF
--- a/lib/subiam/client.rb
+++ b/lib/subiam/client.rb
@@ -138,7 +138,7 @@ class Subiam::Client
     end
 
     if expected_login_profile and not actual_login_profile
-      expected_login_profile[:password] ||= @password_manager.identify(user_name, :login_profile)
+      expected_login_profile[:password] ||= @password_manager.identify(user_name, :login_profile, @driver.password_policy)
       @driver.create_login_profile(user_name, expected_login_profile)
       updated = true
     elsif not expected_login_profile and actual_login_profile

--- a/lib/subiam/driver.rb
+++ b/lib/subiam/driver.rb
@@ -431,6 +431,14 @@ class Subiam::Driver
     end
   end
 
+  def password_policy
+    return @password_policy if instance_variable_defined?(:@password_policy)
+
+    @password_policy = @iam.get_account_password_policy.password_policy
+  rescue Aws::IAM::Errors::NoSuchEntity
+    @password_policy = nil
+  end
+
   private
 
   def encode_document(policy_document)

--- a/lib/subiam/password_manager.rb
+++ b/lib/subiam/password_manager.rb
@@ -1,13 +1,19 @@
 class Subiam::PasswordManager
   include Subiam::Logger::Helper
 
+  LOWERCASES = ('a'..'z').to_a
+  UPPERCASES = ('A'..'Z').to_a
+  NUMBERS = ('0'..'9').to_a
+  SYMBOLS = "!@\#$%^&*()_+-=[]{}|'".split(//)
+
   def initialize(output, options = {})
     @output = output
     @options = options
   end
 
-  def identify(user, type)
-    password = mkpasswd
+  def identify(user, type, policy)
+    password = mkpasswd(policy)
+    log(:info, "mkpasswd: #{password}")
     puts_password(user, type, password)
     password
   end
@@ -22,8 +28,21 @@ class Subiam::PasswordManager
 
   private
 
-  def mkpasswd(len = 8)
-    [*1..9, *'A'..'Z', *'a'..'z'].shuffle.slice(0, len).join
+  def mkpasswd(policy)
+    chars = []
+    len = 8
+
+    if policy
+      len = policy.minimum_password_length if policy.minimum_password_length > len
+      chars << LOWERCASES.shuffle.first if policy.require_lowercase_characters
+      chars << UPPERCASES.shuffle.first if policy.require_uppercase_characters
+      chars << NUMBERS.shuffle.first if policy.require_numbers
+      chars << SYMBOLS.shuffle.first if policy.require_symbols
+
+      len -= chars.length
+    end
+
+    (chars + [*1..9, *'A'..'Z', *'a'..'z'].shuffle.slice(0, len)).shuffle.join
   end
 
   def open_output

--- a/lib/subiam/password_manager.rb
+++ b/lib/subiam/password_manager.rb
@@ -13,7 +13,7 @@ class Subiam::PasswordManager
 
   def identify(user, type, policy)
     password = mkpasswd(policy)
-    log(:info, "mkpasswd: #{password}")
+    log(:debug, "mkpasswd: #{password}")
     puts_password(user, type, password)
     password
   end


### PR DESCRIPTION
user作成時の初期パスワード生成処理が古いままなので、現在のAWSのパスワードポリシーを満たしておらず、apply時にAWS側からのvalidation errorで失敗してしまいます。

> [ERROR] Password does not conform to the account password policy.

このPRで積んだ2コミットは、単純にmiamとの差分をそのまま適用した形です。
ref: https://github.com/codenize-tools/miam/commits/804e42d2653508516caf99e45cb719d63cbafe87/lib/miam/password_manager.rb