### PR TITLE
Migrate to AWS SDK v3

### DIFF
--- a/lib/subiam.rb
+++ b/lib/subiam.rb
@@ -5,7 +5,7 @@ require 'pp'
 require 'singleton'
 require 'thread'
 
-require 'aws-sdk-core'
+require 'aws-sdk-iam'
 Aws.use_bundled_cert!
 
 require 'ruby-progressbar'

--- a/subiam.gemspec
+++ b/subiam.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aws-sdk-core', '~> 2.3'
+  spec.add_dependency 'aws-sdk-iam', '~> 1'
   spec.add_dependency 'ruby-progressbar'
   spec.add_dependency 'parallel'
   spec.add_dependency 'term-ansicolor'


### PR DESCRIPTION
The aws-sdk v2 is deprecated.
This PR upgrades aws-sdk to v3.